### PR TITLE
Pattern matching style handlers for TransactionSynchronizationManager

### DIFF
--- a/src/main/scala/org/springframework/scala/transaction/support/SynchronizationEvent.scala
+++ b/src/main/scala/org/springframework/scala/transaction/support/SynchronizationEvent.scala
@@ -1,5 +1,21 @@
 package org.springframework.scala.transaction.support
 
+/*
+ * Copyright 2002-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /**
  * Base trait for the events triggered by the Spring
  * [[org.springframework.transaction.support.TransactionSynchronizationManager]].

--- a/src/main/scala/org/springframework/scala/transaction/support/TransactionSynchronizationManager.scala
+++ b/src/main/scala/org/springframework/scala/transaction/support/TransactionSynchronizationManager.scala
@@ -1,5 +1,21 @@
 package org.springframework.scala.transaction.support
 
+/*
+ * Copyright 2002-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import org.springframework.transaction.support.TransactionSynchronization
 import org.springframework.transaction.support.{TransactionSynchronizationManager => DelegateSynchronizationManager}
 

--- a/src/test/scala/org/springframework/scala/transaction/support/TransactionSynchronizationManagerTests.scala
+++ b/src/test/scala/org/springframework/scala/transaction/support/TransactionSynchronizationManagerTests.scala
@@ -1,5 +1,21 @@
 package org.springframework.scala.transaction.support
 
+/*
+ * Copyright 2002-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import org.scalatest.FunSuite
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder
 import org.springframework.jdbc.datasource.DataSourceTransactionManager


### PR DESCRIPTION
Hi,

What about a little patch that would make possible to handle TransactionSynchronization using pattern matching instead of anonymous inner classes?

```
// Ugly Scala
TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronizationAdapter(){
    override def afterCompletion(status: Int) {
      if(status == COMMITTED) emailService.sendUserNotification(...)
    }
})

// Pretty Scala
TransactionSynchronizationManager.registerSynchronization {
  case AfterCompletionEvent(status) => if(status == COMMITTED)  emailService.sendUserNotification(...)
}
```

Using Partial Functions for callbacks is much more "scalish" than relaying on anonymous inner classes.
