### PR TITLE
Added AnnotationConfigSupport.

### DIFF
--- a/src/main/scala/org/springframework/scala/context/function/AnnotationConfigSupport.scala
+++ b/src/main/scala/org/springframework/scala/context/function/AnnotationConfigSupport.scala
@@ -1,0 +1,9 @@
+package org.springframework.scala.context.function
+
+trait AnnotationConfigSupport {
+
+  self: FunctionalConfiguration =>
+
+  annotationConfig = true
+
+}

--- a/src/main/scala/org/springframework/scala/context/function/FunctionalConfiguration.scala
+++ b/src/main/scala/org/springframework/scala/context/function/FunctionalConfiguration.scala
@@ -25,7 +25,7 @@ import org.springframework.util.StringUtils
 import org.springframework.util.Assert.state
 import org.springframework.beans.factory.config.{BeanDefinition, BeanDefinitionHolder, ConfigurableBeanFactory}
 import scala.collection.mutable.ListBuffer
-import org.springframework.context.annotation.AnnotatedBeanDefinitionReader
+import org.springframework.context.annotation.{AnnotationConfigUtils, AnnotatedBeanDefinitionReader}
 import org.springframework.beans.factory.support.{RootBeanDefinition, BeanNameGenerator, BeanDefinitionRegistry, BeanDefinitionReaderUtils}
 import scala.reflect.runtime.universe._
 import scala.reflect.runtime.currentMirror
@@ -61,6 +61,8 @@ trait FunctionalConfiguration extends DelayedInit {
 	private var applicationContext: GenericApplicationContext = _
 
 	private var beanNameGenerator: BeanNameGenerator = _
+
+    protected var annotationConfig = false
 
 	private def initDestroyProcessor: InitDestroyFunctionBeanPostProcessor = {
 		assert(beanFactory.containsBean(INIT_DESTROY_FUNCTION_PROCESSOR_BEAN_NAME),
@@ -292,6 +294,10 @@ trait FunctionalConfiguration extends DelayedInit {
 		registerInitDestroyProcessor()
 
 		initCode.foreach(_())
+
+      if(annotationConfig) {
+        AnnotationConfigUtils.registerAnnotationConfigProcessors(applicationContext)
+      }
 	}
 
 	private def registerInitDestroyProcessor() {

--- a/src/test/scala/org/springframework/scala/context/function/AnnotationConfigSupportTests.scala
+++ b/src/test/scala/org/springframework/scala/context/function/AnnotationConfigSupportTests.scala
@@ -1,0 +1,86 @@
+package org.springframework.scala.context.function
+
+import org.scalatest.FunSuite
+import org.springframework.beans.factory.annotation.Autowired
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+import org.scalatest.matchers.ShouldMatchers
+
+@RunWith(classOf[JUnitRunner])
+class AnnotationConfigSupportTests extends FunSuite with ShouldMatchers {
+
+  test("config with trait") {
+    val context = new FunctionalConfigApplicationContext(classOf[ConfigWithTrait])
+    val outerBean = context.getBean(classOf[OuterBean])
+    outerBean.innerBean should not be (null)
+  }
+
+  test("config without trait") {
+    val context = new FunctionalConfigApplicationContext(classOf[ConfigWithoutTrait])
+    val outerBean = context.getBean(classOf[OuterBean])
+    outerBean.innerBean should not be (null)
+  }
+
+  test("should not autowire by default") {
+    val context = new FunctionalConfigApplicationContext(classOf[ConfigWithoutAnnotationSupport])
+    val outerBean = context.getBean(classOf[OuterBean])
+    outerBean.innerBean should be (null)
+  }
+
+  test("DSL value should override trait") {
+    val context = new FunctionalConfigApplicationContext(classOf[ConfigOverridingTrait])
+    val outerBean = context.getBean(classOf[OuterBean])
+    outerBean.innerBean should be (null)
+  }
+
+}
+
+// Test configurations
+
+class ConfigWithTrait extends FunctionalConfiguration with AnnotationConfigSupport {
+
+  bean("inner")(new InnerBean())
+
+  bean("outer")(new OuterBean())
+
+}
+
+class ConfigWithoutTrait extends FunctionalConfiguration {
+
+  annotationConfig = true
+
+  bean("inner")(new InnerBean())
+
+  bean("outer")(new OuterBean())
+
+}
+
+class ConfigWithoutAnnotationSupport extends FunctionalConfiguration {
+
+  bean("inner")(new InnerBean())
+
+  bean("outer")(new OuterBean())
+
+}
+
+class ConfigOverridingTrait extends FunctionalConfiguration with AnnotationConfigSupport {
+
+  annotationConfig = false
+
+  bean("inner")(new InnerBean())
+
+  bean("outer")(new OuterBean())
+
+}
+
+// Test beans
+
+class OuterBean {
+
+  @Autowired
+  var innerBean : InnerBean = _
+
+}
+
+class InnerBean {
+}


### PR DESCRIPTION
Hi,

I've been browsing through the Spring Scala Jira and spotted issue [1] related to the autowiring support in Spring Scala.

While the author of the issue can just register regular `AutowiredAnnotationBeanPostProcessor` bean in order to use `@Inject` in his beans, this is not in sync with configuration style used in Spring XML.

In XML we would use `<context:annotation-config/>`. This is more higher level (aka DSL) approach than registering `AutowiredAnnotationBeanPostProcessor` explicitly in the context. The additional value gained from the `<context:annotation-config/>` is that it registers some other useful bean processors and that it uses `AnnotationConfigUtils#registerAnnotationConfigProcessors` under the hood. The usage of `AnnotationConfigUtils` cannot be overemphasized as it guarantees that only single instance of each annotation processor will be registered in the context.

I think that Scala Spring users should get their `<annotation-config/>` DSL to enable annotation-based configuration as well.

```
class ConfigWithoutTrait extends FunctionalConfiguration {

  annotationConfig = true

  bean("foo")(new Foo())

}
```

For Scala user preferring cake-like [2] configuration style we should provide `AnnotationConfigSupport` trait as well. The latter trait would enable annotation config the same way as `annotationConfig = true` does.

```
class ConfigWithoutTrait extends FunctionalConfiguration with AnnotationConfigSupport {

  bean("foo")(new Foo())

}
```

I believe that the proposed approach is the Scala-like way to provide this useful functionality to the `FunctionalConfiguration` users while keeping consistent style with the existing Spring XML goodies. What do you think about this idea?

[1] https://jira.springsource.org/browse/SCALA-5
[2] http://jonasboner.com/2008/10/06/real-world-scala-dependency-injection-di
