### PR TITLE
Fixed BeanPostProcessor detection.

### DIFF
--- a/src/main/java/org/springframework/scala/beans/factory/function/Function0Wrapper.java
+++ b/src/main/java/org/springframework/scala/beans/factory/function/Function0Wrapper.java
@@ -16,6 +16,7 @@
 
 package org.springframework.scala.beans.factory.function;
 
+import org.springframework.beans.factory.config.BeanPostProcessor;
 import scala.Function0;
 
 /**
@@ -36,5 +37,9 @@ public class Function0Wrapper {
 	public static <T> T apply(Function0<T> function) {
 		return function.apply();
 	}
+
+    public static BeanPostProcessor applyAsBeanPostProcessor(Function0<BeanPostProcessor> function) {
+        return function.apply();
+     }
 
 }

--- a/src/main/scala/org/springframework/scala/beans/factory/function/FunctionalGenericBeanDefinition.scala
+++ b/src/main/scala/org/springframework/scala/beans/factory/function/FunctionalGenericBeanDefinition.scala
@@ -17,6 +17,7 @@
 package org.springframework.scala.beans.factory.function
 
 import org.springframework.beans.factory.support.GenericBeanDefinition
+import org.springframework.beans.factory.config.BeanPostProcessor
 
 /**
  * Default implementation of
@@ -24,12 +25,14 @@ import org.springframework.beans.factory.support.GenericBeanDefinition
  *
  * @author Arjen Poutsma
  */
-class FunctionalGenericBeanDefinition[T](beanFunction: () => T)
+class FunctionalGenericBeanDefinition[T](beanFunction: () => T)(implicit manifest: Manifest[T])
 		extends GenericBeanDefinition with FunctionalBeanDefinition[T] {
 
 	setBeanClass(classOf[Function0Wrapper])
 	getConstructorArgumentValues.addIndexedArgumentValue(0, beanFunction)
-	setFactoryMethodName("apply")
+	val isBeanPostProcessor = classOf[BeanPostProcessor].isAssignableFrom(manifest.runtimeClass)
+	val factoryMethodName = if(isBeanPostProcessor) "applyAsBeanPostProcessor" else "apply"
+	setFactoryMethodName(factoryMethodName)
 
 	def beanCreationFunction = beanFunction
 }

--- a/src/main/scala/org/springframework/scala/context/function/FunctionalConfiguration.scala
+++ b/src/main/scala/org/springframework/scala/context/function/FunctionalConfiguration.scala
@@ -141,7 +141,7 @@ trait FunctionalConfiguration extends DelayedInit {
 
 		val beanType = manifest.runtimeClass.asInstanceOf[Class[T]]
 
-		val fbd = new FunctionalGenericBeanDefinition(beanFunction)
+		val fbd = new FunctionalGenericBeanDefinition(beanFunction)(manifest)
 		fbd.setScope(scope)
 		fbd.setLazyInit(lazyInit)
 

--- a/src/test/scala/org/springframework/scala/beans/factory/function/BeanPostProcessorTests.scala
+++ b/src/test/scala/org/springframework/scala/beans/factory/function/BeanPostProcessorTests.scala
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2011-2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.scala.beans.factory.function
+
+import org.scalatest.FunSuite
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+import org.springframework.scala.context.function.{FunctionalConfigApplicationContext, FunctionalConfiguration}
+import org.springframework.beans.factory.annotation.{AutowiredAnnotationBeanPostProcessor, Autowired}
+import org.scalatest.matchers.ShouldMatchers
+
+@RunWith(classOf[JUnitRunner])
+class BeanPostProcessorTests extends FunSuite with ShouldMatchers {
+
+  val applicationContext = new FunctionalConfigApplicationContext(classOf[ConfigWithBeanPostProcessor])
+
+  test("BeanPostProcessor support") {
+    applicationContext.getBean(classOf[AutowireSubject]).autowiredMember should not be (null)
+  }
+
+}
+
+class ConfigWithBeanPostProcessor extends FunctionalConfiguration {
+
+  bean()(new AutowiredAnnotationBeanPostProcessor)
+
+  bean()("autowireMe")
+
+  bean()(new AutowireSubject)
+
+}
+
+class AutowireSubject {
+
+  @Autowired
+  var autowiredMember : String = _
+
+}


### PR DESCRIPTION
Hi,

While playing around with `FunctionalConfiguration` I've discovered that `BeanPostProcessor` instances registered in the context via `bean()` DSL method do not processes the beans as they ought to.

The minimal example of such broken configuration is demonstrated below.

```
class ConfigWithBeanPostProcessor extends FunctionalConfiguration {

  bean()(new AutowiredAnnotationBeanPostProcessor)

  bean()("autowireMe")

  bean()(new AutowireSubject)

}

class AutowireSubject {

  @Autowired
  var autowiredMember : String = _

}
```

What we expect here is that String will be injected into the `AutowireSubject` as `autowiredMember`. Unfortunately it is not true.

I couldn't resist the temptation and investigated this problem a little bit. The issue is that `FunctionalConfiguration#bean` method registers the `Function0Wrapper` instance which is responsible for creating the actual `BeanPostProcessor` object. However `AbstractBeanFactory#isFactoryBean` method cannot recognize that `Function0Wrapper#apply` method returns `BeanPostProcessor` instance because the return type of the latter method is parameterized as `<T>` (i.e. returns `Object` for the reflection API).

I definitely don't feel like Spring internals expert, but the solution that seems reasonable for me is to recognize on the `FunctionalGenericBeanDefinition` level if the wrapped function returns `BeanPostProcessor`. If so, then `FunctionalGenericBeanDefinition` should be created with the special version of `Function0Wrapper#apply` method called (let's say) `Function0Wrapper#applyAsBeanPostProcessor`. The latter factory method would wrap `Function0<BeanPostProcessor>` instances and explicitly define `BeanPostProcessor` return type. If `Function0Wrapper` factory method defined on `FunctionalGenericBeanDefinition` has return type of `BeanPostProcessor`, then  `AbstractBeanFactory#isFactoryBean` works like a charm. And `AbstractBeanFactory#isFactoryBean` method working properly resolves the issue, as `AbstractApplicationContext#registerBeanPostProcessors` can recognize that instance return by `Function0Wrapper` is a `BeanPostProcessor`.

The pull request contains both fix and test case for it.

Best regards.
