### PR TITLE
Added component scan mini DSL.

### DIFF
--- a/src/test/scala/org/springframework/scala/context/function/ComponentScanTests.scala
+++ b/src/test/scala/org/springframework/scala/context/function/ComponentScanTests.scala
@@ -2,7 +2,7 @@ package org.springframework.scala.context.function
 
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
-import org.scalatest.{GivenWhenThen, BeforeAndAfter, FunSuite}
+import org.scalatest.{GivenWhenThen, FunSuite}
 import org.scalatest.matchers.ShouldMatchers
 import org.springframework.stereotype.Component
 import org.springframework.context.annotation.{AnnotationScopeMetadataResolver, ScopedProxyMode}
@@ -88,7 +88,7 @@ class VarArgComponentScanConfig extends FunctionalConfiguration with ContextSupp
 class ScopeConflictComponentScanConfig extends FunctionalConfiguration with ContextSupport {
 
   componentScan(basePackages = Seq("org.springframework.scala.context.function"),
-    scopedProxy = ScopedProxyMode.TARGET_CLASS, scopeResolver = new AnnotationScopeMetadataResolver)
+    scopedProxy = Some(ScopedProxyMode.TARGET_CLASS), scopeResolver = Some(new AnnotationScopeMetadataResolver))
 
 }
 


### PR DESCRIPTION
Hi,

I've added `ContextSupport#componentScan` methods to provide elegant way to enable component scanning in `FunctionalConfiguration`.

We can either configure scanning via named parameters...

```
class ExcludingComponentScanConfig extends FunctionalConfiguration with ContextSupport {

  componentScan(basePackages = Seq("org.springframework.scala.context.function"),
    excludeFilters = Seq(new RegexPatternTypeFilter(Pattern.compile(".*Component"))),
    scopedProxy = ScopedProxyMode.TARGET_CLASS)

}
```

...or via varArged list of base packages...

```
class VarArgComponentScanConfig extends FunctionalConfiguration with ContextSupport             {

  componentScan("com.packageone", "com.packagetwo")

}
```

What do you think? Javadoc on pull request acceptance, as usually :)

Cheers. 
