### PR TITLE
Fixed stackoverflow exception bug in FunctionalConfigApplicationContext.

### DIFF
--- a/src/main/scala/org/springframework/scala/context/function/FunctionalConfigApplicationContext.scala
+++ b/src/main/scala/org/springframework/scala/context/function/FunctionalConfigApplicationContext.scala
@@ -81,11 +81,13 @@ class FunctionalConfigApplicationContext
 		configurations.foreach(_.register(this, beanNameGenerator))
 	}
 
-	def apply[T]()(implicit manifest: Manifest[T]) = richApplicationContext
-			.apply()(manifest)
+	def apply[T]()(implicit manifest: Manifest[T]) = {
+		getBean(manifestToClass(manifest))
+	}
 
-	def apply[T](name: String)(implicit manifest: Manifest[T]) = richApplicationContext
-			.apply(name)(manifest)
+	def apply[T](name: String)(implicit manifest: Manifest[T]) = {
+		getBean(name, manifestToClass(manifest))
+	}
 
 	def beanNamesForType[T](includeNonSingletons: Boolean, allowEagerInit: Boolean)
 	                       (implicit manifest: Manifest[T]) = richApplicationContext

--- a/src/test/scala/org/springframework/scala/context/function/FunctionalConfigApplicationContextTests.scala
+++ b/src/test/scala/org/springframework/scala/context/function/FunctionalConfigApplicationContextTests.scala
@@ -59,6 +59,16 @@ class FunctionalConfigApplicationContextTests extends FunSuite {
 		assert("Foo" == foo)
 	}
 
+  test("context[Class]") {
+    val appContext = FunctionalConfigApplicationContext(classOf[MyFunctionalConfiguration])
+    val foo = appContext[String]
+    assert("Foo" == foo)
+  }
 
+  test("context[Class]('beanName')") {
+    val appContext = FunctionalConfigApplicationContext(classOf[MyFunctionalConfiguration])
+    val foo = appContext[String]("foo")
+    assert("Foo" == foo)
+  }
 
 }


### PR DESCRIPTION
Hi,

Unfortunately we can experience a stack overflow exception when calling our new cool companion methods on `FunctionalConfigApplicationContext`.

```
val appContext = FunctionalConfigApplicationContext(classOf[MyFunctionalConfiguration])
appContext[String] // Stack overflow
...
appContext[String]("foo") // Yet another stack overflow
```

I've created two tests demonstrating the issue and submitted appropriate fix.

Cheers.
