### PR TITLE
Started migration to new Scala 2.10 Type Tag API.

### DIFF
--- a/src/main/scala/org/springframework/scala/beans/factory/BeanFactoryConversions.scala
+++ b/src/main/scala/org/springframework/scala/beans/factory/BeanFactoryConversions.scala
@@ -18,7 +18,8 @@ package org.springframework.scala.beans.factory
 
 import org.springframework.beans.factory.{ListableBeanFactory, BeanFactory}
 import scala.collection.JavaConversions._
-import org.springframework.scala.util.ManifestUtils.manifestToClass
+import org.springframework.scala.util.TypeTagUtils.typeToClass
+import scala.reflect.ClassTag
 
 /**
  * A collection of implicit conversions between bean factories and their rich counterpart.
@@ -52,12 +53,12 @@ object BeanFactoryConversions {
 private[springframework] class DefaultRichBeanFactory(val beanFactory: BeanFactory)
 		extends RichBeanFactory {
 
-	def apply[T]()(implicit manifest: Manifest[T]) = {
-		beanFactory.getBean(manifestToClass(manifest))
+	def apply[T : ClassTag]() = {
+		beanFactory.getBean(typeToClass[T])
 	}
 
-	def apply[T](name: String)(implicit manifest: Manifest[T]) = {
-		beanFactory.getBean(name, manifestToClass(manifest))
+	def apply[T : ClassTag](name: String) = {
+		beanFactory.getBean(name, typeToClass[T])
 	}
 
 }
@@ -65,18 +66,17 @@ private[springframework] class DefaultRichBeanFactory(val beanFactory: BeanFacto
 private[springframework] class DefaultRichListableBeanFactory(beanFactory: ListableBeanFactory)
 		extends DefaultRichBeanFactory(beanFactory) with RichListableBeanFactory {
 
-	def beanNamesForType[T](includeNonSingletons: Boolean = true,
-	                        allowEagerInit: Boolean = true)
-	                       (implicit manifest: Manifest[T]): Seq[String] = {
-		beanFactory.getBeanNamesForType(manifestToClass(manifest),
+	def beanNamesForType[T : ClassTag](includeNonSingletons: Boolean = true,
+	                        allowEagerInit: Boolean = true): Seq[String] = {
+		beanFactory.getBeanNamesForType(typeToClass[T],
 		                                includeNonSingletons,
 		                                allowEagerInit)
 	}
 
-	def beansOfType[T](includeNonSingletons: Boolean = true, allowEagerInit: Boolean = true)
-	                  (implicit manifest: Manifest[T]): Map[String, T] = {
+	def beansOfType[T : ClassTag](includeNonSingletons: Boolean = true,
+                                allowEagerInit: Boolean = true): Map[String, T] = {
 		beanFactory
-				.getBeansOfType(manifestToClass(manifest), includeNonSingletons, allowEagerInit)
+				.getBeansOfType(typeToClass[T], includeNonSingletons, allowEagerInit)
 				.toMap
 	}
 

--- a/src/main/scala/org/springframework/scala/beans/factory/RichBeanFactory.scala
+++ b/src/main/scala/org/springframework/scala/beans/factory/RichBeanFactory.scala
@@ -18,6 +18,7 @@ package org.springframework.scala.beans.factory
 
 import org.springframework.beans.factory.{BeanNotOfRequiredTypeException, NoUniqueBeanDefinitionException, NoSuchBeanDefinitionException}
 import org.springframework.beans.BeansException
+import scala.reflect.ClassTag
 
 /**
  * Rich wrapper for [[org.springframework.beans.factory.BeanFactory]], offering
@@ -35,9 +36,9 @@ trait RichBeanFactory {
 	 *         or `None` if no such bean was found
 	 */
 	@throws(classOf[NoUniqueBeanDefinitionException])
-	def bean[T]()(implicit manifest: Manifest[T]): Option[T] = {
+	def bean[T : ClassTag](): Option[T] = {
 		try {
-			Option(apply()(manifest))
+			Option(apply[T]())
 		}
 		catch {
 			case _: NoSuchBeanDefinitionException => None
@@ -55,7 +56,7 @@ trait RichBeanFactory {
 	 */
 	@throws(classOf[NoSuchBeanDefinitionException])
 	@throws(classOf[NoUniqueBeanDefinitionException])
-	def apply[T]()(implicit manifest: Manifest[T]): T
+	def apply[T : ClassTag](): T
 
 	/**
 	 * Optionally returns an instance, which may be shared or independent, of the specified
@@ -69,9 +70,9 @@ trait RichBeanFactory {
 	 * @throws BeansException if the bean could not be created
 	 */
 	@throws(classOf[BeansException])
-	def bean[T](name: String)(implicit manifest: Manifest[T]): Option[T] = {
+	def bean[T : ClassTag](name: String): Option[T] = {
 		try {
-			Option(apply(name)(manifest))
+			Option(apply[T](name))
 		}
 		catch {
 			case _: NoSuchBeanDefinitionException => None
@@ -93,6 +94,6 @@ trait RichBeanFactory {
 	@throws(classOf[NoSuchBeanDefinitionException])
 	@throws(classOf[BeanNotOfRequiredTypeException])
 	@throws(classOf[BeansException])
-	def apply[T](name: String)(implicit manifest: Manifest[T]): T
+	def apply[T : ClassTag](name: String): T
 
 }

--- a/src/main/scala/org/springframework/scala/beans/factory/RichListableBeanFactory.scala
+++ b/src/main/scala/org/springframework/scala/beans/factory/RichListableBeanFactory.scala
@@ -16,6 +16,8 @@
 
 package org.springframework.scala.beans.factory
 
+import scala.reflect.ClassTag
+
 /**
  * Rich wrapper for [[org.springframework.beans.factory.ListableBeanFactory]], offering
  * Scala-specific methods.
@@ -55,9 +57,7 @@ trait RichListableBeanFactory extends RichBeanFactory {
 	 * @see FactoryBean#getObjectType
 	 * @see BeanFactoryUtils#beanNamesForTypeIncludingAncestors(ListableBeanFactory, Class, boolean, boolean)
 	 */
-	def beanNamesForType[T](includeNonSingletons: Boolean = true,
-	                        allowEagerInit: Boolean = true)
-	                       (implicit manifest: Manifest[T]): Seq[String]
+	def beanNamesForType[T : ClassTag](includeNonSingletons: Boolean = true, allowEagerInit: Boolean = true): Seq[String]
 
 	/**
 	 * Return the bean instances that match the given object type (including
@@ -95,7 +95,6 @@ trait RichListableBeanFactory extends RichBeanFactory {
 	 * @see FactoryBean#getObjectType
 	 * @see BeanFactoryUtils#beansOfTypeIncludingAncestors(ListableBeanFactory, Class, boolean, boolean)
 	 */
-	def beansOfType[T](includeNonSingletons: Boolean = true, allowEagerInit: Boolean = true)
-	                  (implicit manifest: Manifest[T]): Map[String, T]
+	def beansOfType[T : ClassTag](includeNonSingletons: Boolean = true, allowEagerInit: Boolean = true) : Map[String, T]
 
 }

--- a/src/main/scala/org/springframework/scala/context/ApplicationContextConversions.scala
+++ b/src/main/scala/org/springframework/scala/context/ApplicationContextConversions.scala
@@ -19,6 +19,7 @@ package org.springframework.scala.context
 import org.springframework.context.ApplicationContext
 import org.springframework.scala.beans.factory.RichListableBeanFactory
 import org.springframework.scala.beans.factory.BeanFactoryConversions._
+import scala.reflect.ClassTag
 
 /**
  * A collection of implicit conversions between application contexts and their rich
@@ -45,16 +46,15 @@ private[springframework] class DefaultRichApplicationContext(val appContext: App
 
 	private val beanFactory: RichListableBeanFactory = appContext
 
-	def apply[T]()(implicit manifest: Manifest[T]) = beanFactory.apply()(manifest)
+	def apply[T : ClassTag]() = beanFactory.apply[T]()
 
-	def apply[T](name: String)(implicit manifest: Manifest[T]) = beanFactory
-			.apply(name)(manifest)
+	def apply[T : ClassTag](name: String) =
+		beanFactory	.apply[T](name)
 
-	def beanNamesForType[T](includeNonSingletons: Boolean, allowEagerInit: Boolean)
-	                       (implicit manifest: Manifest[T]) = beanFactory
-			.beanNamesForType(includeNonSingletons, allowEagerInit)(manifest)
+	def beanNamesForType[T : ClassTag](includeNonSingletons: Boolean, allowEagerInit: Boolean) =
+		beanFactory.beanNamesForType[T](includeNonSingletons, allowEagerInit)
 
-	def beansOfType[T](includeNonSingletons: Boolean, allowEagerInit: Boolean)
-	                  (implicit manifest: Manifest[T]) = beanFactory
-			.beansOfType(includeNonSingletons, allowEagerInit)(manifest)
+	def beansOfType[T : ClassTag](includeNonSingletons: Boolean, allowEagerInit: Boolean) =
+		beanFactory.beansOfType[T](includeNonSingletons, allowEagerInit)
+
 }

--- a/src/main/scala/org/springframework/scala/util/TypeTagUtils.scala
+++ b/src/main/scala/org/springframework/scala/util/TypeTagUtils.scala
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2011-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.scala.util
+
+import scala.reflect.ClassTag
+import scala.reflect.classTag
+
+/**
+ * Miscellaneous ``TypeTag`` (and ``ClassTag``) utility methods for internal use within the
+ * framework.
+ *
+ *@author Henryk Konsek
+ */
+private[springframework] object TypeTagUtils {
+
+  /**
+   * Returns the [[java.lang.Class]] corresponding to the given class tag.
+   *
+   * @param tag the class tag to convert
+   * @tparam T the tag's bound type
+   * @return the runtime class of the tag
+   */
+	def tagToClass[T](tag: ClassTag[T]): Class[T] = {
+		tag.runtimeClass.asInstanceOf[Class[T]]
+	}
+
+  /**
+   * Returns the [[java.lang.Class]] corresponding to the given type.
+   *
+   * @tparam T the bound type to convert
+   * @return the runtime class of the given type
+   */
+  def typeToClass[T : ClassTag] = {
+    tagToClass(classTag[T])
+  }
+
+}


### PR DESCRIPTION
Hi,

As Manifests will become deprecated in the coming version of Scala, we should migrate them to new Type Tag API [1]. As a bonus we got really sexy and neat `ClassTag` syntax, instead of the manifest implicits boilerplate.

I've migrated some classes from manifests to `ClassTags`. New code looks much clearer.

If you merge this pull request to the master, I'll handle the migration of the rest of the code base in coming weeks.

Thanks for @aloiscochard for friendly reminder that we should start the migration effort.

Cheers.

[1] http://docs.scala-lang.org/overviews/reflection/overview.html
