### PR TITLE
Basic support for Cake pattern based configuration.

### DIFF
--- a/src/main/scala/org/springframework/scala/context/function/cake/Cake.scala
+++ b/src/main/scala/org/springframework/scala/context/function/cake/Cake.scala
@@ -1,0 +1,24 @@
+package org.springframework.scala.context.function.cake
+
+import org.springframework.scala.context.function.FunctionalConfiguration
+import scala.collection.mutable.ListBuffer
+
+class Cake(initialConfigurationClasses: Class[_ <: FunctionalConfiguration]*) extends CakeApplicationContext with CakeLifecycle {
+
+  // Members
+
+  private[cake] val _configurationClasses = new ListBuffer[Class[_ <: FunctionalConfiguration]]()
+
+  // Initialization
+
+  _configurationClasses ++= initialConfigurationClasses
+  startApplicationContext()
+
+  // Lifecycle routines
+
+  protected def startApplicationContext() {
+    _configurationClasses.foreach(applicationContext.registerClasses(_))
+    applicationContext.refresh()
+  }
+
+}

--- a/src/main/scala/org/springframework/scala/context/function/cake/CakeApplicationContext.scala
+++ b/src/main/scala/org/springframework/scala/context/function/cake/CakeApplicationContext.scala
@@ -1,0 +1,35 @@
+package org.springframework.scala.context.function.cake
+
+import org.springframework.context.ApplicationContext
+import org.springframework.scala.context.function.{FunctionalConfiguration, FunctionalConfigApplicationContext}
+import org.springframework.beans.factory.config.ConfigurableBeanFactory
+import org.springframework.scala.util.ManifestUtils._
+import scala.collection.mutable.ListBuffer
+
+trait CakeApplicationContext {
+
+  // Public API
+
+  def context: ApplicationContext = applicationContext
+
+  // Internal Cake API
+
+  private[cake] val configuration = new FunctionalConfiguration {}
+
+  private[cake] val applicationContext = new FunctionalConfigApplicationContext()
+  applicationContext.registerConfigurations(configuration)
+
+  private[cake] val beanFunctions = ListBuffer[() => _ <: Any]()
+
+  private[cake] def registerFunctionalBeanDefinition[T](beanName: String, aliases: Seq[String],
+                                                        scope: String, lazyInit: Boolean)
+                                                       (beanFunction: () => T)
+                                                       (implicit manifest: Manifest[T]): () => T = {
+    configuration.registerBean(beanName, aliases, scope, lazyInit, beanFunction, manifest)
+    if (beanName.isEmpty)
+      () => applicationContext.getBean(manifestToClass(manifest))
+    else
+      () => applicationContext.bean(beanName).get
+  }
+
+}

--- a/src/main/scala/org/springframework/scala/context/function/cake/CakeLifecycle.scala
+++ b/src/main/scala/org/springframework/scala/context/function/cake/CakeLifecycle.scala
@@ -1,0 +1,7 @@
+package org.springframework.scala.context.function.cake
+
+trait CakeLifecycle { self: Cake =>
+
+  protected def startApplicationContext()
+
+}

--- a/src/main/scala/org/springframework/scala/context/function/cake/CakeSupport.scala
+++ b/src/main/scala/org/springframework/scala/context/function/cake/CakeSupport.scala
@@ -1,0 +1,19 @@
+package org.springframework.scala.context.function.cake
+
+import org.springframework.beans.factory.config.ConfigurableBeanFactory
+
+
+trait CakeSupport extends CakeApplicationContext {
+
+  protected def bean[T](beanName: String = "", aliases: Seq[String] = Seq(),
+                        scope: String = ConfigurableBeanFactory.SCOPE_SINGLETON, lazyInit: Boolean = true)
+                       (beanFunction: => T)(implicit manifest: Manifest[T]): () => T = {
+    registerFunctionalBeanDefinition(beanName, aliases, scope, lazyInit)(beanFunction _)
+  }
+
+  protected def singleton[T](beanFunction: => T)(implicit manifest: Manifest[T]): () => T = {
+    bean()(beanFunction)
+  }
+
+}
+

--- a/src/main/scala/org/springframework/scala/context/function/cake/FunctionalConfigurationSupport.scala
+++ b/src/main/scala/org/springframework/scala/context/function/cake/FunctionalConfigurationSupport.scala
@@ -1,0 +1,14 @@
+package org.springframework.scala.context.function.cake
+
+import org.springframework.scala.context.function.FunctionalConfiguration
+
+trait FunctionalConfigurationSupport extends CakeLifecycle { self: Cake =>
+
+  def configurationClass : Class[_ <: FunctionalConfiguration]
+
+  abstract override protected def startApplicationContext() {
+    _configurationClasses += configurationClass
+    super.startApplicationContext()
+  }
+
+}

--- a/src/main/scala/org/springframework/scala/context/function/cake/FunctionalConfigurationsSupport.scala
+++ b/src/main/scala/org/springframework/scala/context/function/cake/FunctionalConfigurationsSupport.scala
@@ -1,0 +1,14 @@
+package org.springframework.scala.context.function.cake
+
+import org.springframework.scala.context.function.FunctionalConfiguration
+
+trait FunctionalConfigurationsSupport extends CakeLifecycle { self: Cake =>
+
+  def configurationClasses : Seq[Class[_ <: FunctionalConfiguration]]
+
+  abstract override protected def startApplicationContext() {
+    _configurationClasses ++= configurationClasses
+    super.startApplicationContext()
+  }
+
+}

--- a/src/test/scala/org/springframework/scala/context/function/cake/CakeObject.scala
+++ b/src/test/scala/org/springframework/scala/context/function/cake/CakeObject.scala
@@ -1,0 +1,10 @@
+package org.springframework.scala.context.function.cake
+
+object CakeObject extends Cake with FunctionalConfigurationSupport
+  with ServiceComponent with DataAccessComponent {
+
+  def configurationClass = classOf[TestFunctionalConfiguration]
+
+  val dao = singleton(new ProductionDao)
+
+}

--- a/src/test/scala/org/springframework/scala/context/function/cake/CakeTests.scala
+++ b/src/test/scala/org/springframework/scala/context/function/cake/CakeTests.scala
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2011-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.scala.context.function.cake
+
+import org.scalatest.{GivenWhenThen, FunSuite}
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+import org.scalatest.matchers.ShouldMatchers
+import org.springframework.scala.beans.factory.BeanFactoryConversions._
+import org.springframework.scala.beans.factory.RichListableBeanFactory
+
+@RunWith(classOf[JUnitRunner])
+class CakeTests extends FunSuite with GivenWhenThen with ShouldMatchers {
+
+  test("should access dependencies via cake") {
+    Given("cake configuration")
+    val cake = new Cake with ServiceComponent with ProductionDataAccessComponent
+
+    When("dependencies are fetched from cake")
+    val service = cake.service()
+    val dao = cake.dao()
+
+    Then("cake should provide all dependencies")
+    service should not be (null)
+    dao should not be (null)
+  }
+
+  test("should access dependencies via ApplicationContext") {
+    Given("cake configuration")
+    val cake = new Cake with ServiceComponent with ProductionDataAccessComponent
+
+    When("dependencies are fetched from ApplicationContext")
+    val context: RichListableBeanFactory = cake.context
+    val service = context[Service]
+    val dao = context[Dao]
+
+    Then("context should provide all dependencies")
+    service should not be (null)
+    dao should not be (null)
+  }
+
+  test("cake and applicationContext should return the same singletons") {
+    Given("cake configuration")
+    val cake = new Cake with ServiceComponent with ProductionDataAccessComponent
+
+    When("dependencies are fetched")
+    val context: RichListableBeanFactory = cake.context
+    val serviceFromContext = context[Service]
+    val daoFromContext = context[Dao]
+    val serviceFromCake = cake.service()
+    val daoFromCake = cake.dao()
+
+    Then("dependencies from cake and applicationContext should be the same")
+    serviceFromContext should be theSameInstanceAs (serviceFromCake)
+    daoFromContext should be theSameInstanceAs (daoFromCake)
+  }
+
+  test("the same DAO should be injected and provided as top level bean") {
+    Given("cake configuration")
+    val cake = new Cake with ServiceComponent with ProductionDataAccessComponent
+
+    When("dependencies are fetched")
+    val topLevelDao = cake.dao()
+    val injectedDao = cake.service().dao
+
+    Then("injected DAO should be the same as top level bean")
+    topLevelDao should be theSameInstanceAs (injectedDao)
+  }
+
+  test("should inject dependencies into global configuration") {
+    When("dependencies are fetched")
+    val dao = CakeObject.dao()
+    val service = CakeObject.service()
+
+    Then("dependencies should not be injected")
+    dao should not be (null)
+    service should not be (null)
+  }
+
+  test("should include additional configuration in the global cake") {
+    Given("global application context has been created")
+    val context: RichListableBeanFactory = CakeObject.context
+
+    When("String bean is fetched")
+    val fooString = context[String]
+
+    Then("String bean should not be null")
+    fooString should equal(TestFunctionalConfiguration.fooString)
+  }
+
+  test("(cake object) the same DAO should be injected and provided as top level bean") {
+    When("dependencies are fetched")
+    val topLevelDao = CakeObject.dao()
+    val injectedDao = CakeObject.service().dao
+
+    Then("injected DAO should be the same as top level bean")
+    topLevelDao should be theSameInstanceAs (injectedDao)
+  }
+
+}

--- a/src/test/scala/org/springframework/scala/context/function/cake/Dao.scala
+++ b/src/test/scala/org/springframework/scala/context/function/cake/Dao.scala
@@ -1,0 +1,3 @@
+package org.springframework.scala.context.function.cake
+
+trait Dao

--- a/src/test/scala/org/springframework/scala/context/function/cake/DataAccessComponent.scala
+++ b/src/test/scala/org/springframework/scala/context/function/cake/DataAccessComponent.scala
@@ -1,0 +1,7 @@
+package org.springframework.scala.context.function.cake
+
+trait DataAccessComponent extends CakeSupport {
+
+  val dao : () => Dao
+
+}

--- a/src/test/scala/org/springframework/scala/context/function/cake/ProductionDataAccessComponent.scala
+++ b/src/test/scala/org/springframework/scala/context/function/cake/ProductionDataAccessComponent.scala
@@ -1,0 +1,9 @@
+package org.springframework.scala.context.function.cake
+
+trait ProductionDataAccessComponent extends DataAccessComponent {
+
+  val dao = singleton(new ProductionDao)
+
+}
+
+class ProductionDao extends Dao

--- a/src/test/scala/org/springframework/scala/context/function/cake/Service.scala
+++ b/src/test/scala/org/springframework/scala/context/function/cake/Service.scala
@@ -1,0 +1,3 @@
+package org.springframework.scala.context.function.cake
+
+case class Service(dao: Dao)

--- a/src/test/scala/org/springframework/scala/context/function/cake/ServiceComponent.scala
+++ b/src/test/scala/org/springframework/scala/context/function/cake/ServiceComponent.scala
@@ -1,0 +1,7 @@
+package org.springframework.scala.context.function.cake
+
+trait ServiceComponent extends CakeSupport { this: DataAccessComponent =>
+
+  val service = singleton(new Service(dao()))
+
+}

--- a/src/test/scala/org/springframework/scala/context/function/cake/TestFunctionalConfiguration.scala
+++ b/src/test/scala/org/springframework/scala/context/function/cake/TestFunctionalConfiguration.scala
@@ -1,0 +1,15 @@
+package org.springframework.scala.context.function.cake
+
+import org.springframework.scala.context.function.FunctionalConfiguration
+
+class TestFunctionalConfiguration extends FunctionalConfiguration {
+
+  bean("fooString")("fooString")
+
+}
+
+object TestFunctionalConfiguration {
+
+  val fooString = "fooString"
+
+}


### PR DESCRIPTION
Hi,

Some people complain that using type-scafe Scala with type-unsafe Spring dependency injection makes no sense. I personally disgaree with such statements, although I think that we could add some optional type-safe checking to the project to laverage the pros of Scala. I therefore created the Cake support for Spring Scala.

Cake support for Spring Scala allows to create type-safe cake view over the entire-, or part of the-, functional application context.

I would like to elaborate a little bit on some concrete example. Imagine the part of the typical Spring application .i.e. `Service` and `Dao`. 

```
trait Dao
class ProductionDao extends Dao
case class Service(dao: Dao)
```

We want to wire these two guys into Spring application context. On the same time we want to take the advantage of the cake pattern in order to:
a) get global access to the application components
b) verify at the compile time that we have provided all necessary dependencies

For this purpose we create typical cake components, but instead of specifying dependencies as `T` we specify them as `() => T`.

```
trait DataAccessComponent extends CakeSupport {
  val dao : () => Dao
}

trait ServiceComponent extends CakeSupport { this: DataAccessComponent =>
  val service = singleton(new Service(dao()))
}
```

Then we wire the dependencies into the global application context.

```
object MyApp extends Cake extends ServiceComponent with DataAccessComponent {
  val dao = singleton(new ProductionDao)
  // val dao = singleton(mock[Dao]) // for tests
}
```

We can use the `CakeObject` as regular Scala cake:

```
val dao = MyApp.dao()
val service = MyApp.service()
dao == service.dao
```

Under the hood, our cake hides regular Spring (functional) application context:

```
val context = MyApp.context
context[Service] == MyApp.service()
```

The magic here is the `singleton` method from the `CakeSupport` trait which registers the function defined as Cake dependency in the application context.

The nice thing in cake for Spring Scala is that you don't have to cover all your Spring dependencies with "caked" components.

```
object CakeObject extends Cake with FunctionalConfigurationSupport
  with ServiceComponent with DataAccessComponent {

  // Beans from this configuration will be available only for the
  // Spring application context and will not be a subject of the
  // compile time type-safe checks.
  def configurationClass = classOf[ComponentScanConfiguration]

  val dao = singleton(new ProductionDao)

}

class ComponentScanConfiguration extends FunctionalConfiguration with ContextSupport {
  componentScan("org.more.dynamic.components")
}
```

Using this approach you can combine the best of both worlds - type-safe cake dependencies and dynamic Spring configuration.

What do you think?

PS Scaladoc available on demand, as usually :) .
