### PR TITLE
Fixed stack overflow exceptions in FunctionalConfigApplicationContext.

### DIFF
--- a/src/main/scala/org/springframework/scala/context/function/FunctionalConfigApplicationContext.scala
+++ b/src/main/scala/org/springframework/scala/context/function/FunctionalConfigApplicationContext.scala
@@ -21,7 +21,7 @@ import org.springframework.util.CollectionUtils
 import scala.collection.JavaConversions._
 import org.springframework.beans.BeanUtils
 import org.springframework.beans.factory.support.{DefaultBeanNameGenerator, BeanNameGenerator}
-import org.springframework.scala.context.RichApplicationContext
+import org.springframework.scala.context.{DefaultRichApplicationContext, RichApplicationContext}
 import org.springframework.scala.util.ManifestUtils.manifestToClass
 
 /**
@@ -44,7 +44,7 @@ class FunctionalConfigApplicationContext
 
 	var beanNameGenerator: BeanNameGenerator = new DefaultBeanNameGenerator
 
-	private val richApplicationContext: RichApplicationContext = this
+	private val richApplicationContext: RichApplicationContext = new DefaultRichApplicationContext(this)
 
 	/**
 	 * Registers a single [[org.springframework.scala.context.function.FunctionalConfiguration]]

--- a/src/test/scala/org/springframework/scala/context/function/FunctionalConfigApplicationContextTests.scala
+++ b/src/test/scala/org/springframework/scala/context/function/FunctionalConfigApplicationContextTests.scala
@@ -59,6 +59,10 @@ class FunctionalConfigApplicationContextTests extends FunSuite {
 		assert("Foo" == foo)
 	}
 
-
+  test("rich ctx[Type]") {
+    val appContext = FunctionalConfigApplicationContext(classOf[MyFunctionalConfiguration])
+    val foo = appContext[String]
+    assert("Foo" === foo)
+  }
 
 }


### PR DESCRIPTION
Hi,

I've spotted another stack overflow problem in `RichApplicationContext`. `FunctionalConfigApplicationContext` delegated "enriched" API method calls to itself. I've made a tiny little change to delegate the execution to the composed `DefaultRichApplicationContext` instead.

Cheers.
