### PR TITLE
Added FunctionalApplicationContext.beansOfType with no params

### DIFF
--- a/src/main/scala/org/springframework/scala/beans/factory/BeanFactoryConversions.scala
+++ b/src/main/scala/org/springframework/scala/beans/factory/BeanFactoryConversions.scala
@@ -80,5 +80,8 @@ private[springframework] class DefaultRichListableBeanFactory(beanFactory: Lista
 				.toMap
 	}
 
+  def beansOfType[T](implicit manifest: Manifest[T]): Map[String, T] =
+    beansOfType[T]()
+
 }
 

--- a/src/main/scala/org/springframework/scala/beans/factory/RichListableBeanFactory.scala
+++ b/src/main/scala/org/springframework/scala/beans/factory/RichListableBeanFactory.scala
@@ -98,4 +98,6 @@ trait RichListableBeanFactory extends RichBeanFactory {
 	def beansOfType[T](includeNonSingletons: Boolean = true, allowEagerInit: Boolean = true)
 	                  (implicit manifest: Manifest[T]): Map[String, T]
 
+	def beansOfType[T](implicit manifest: Manifest[T]): Map[String, T]
+
 }

--- a/src/main/scala/org/springframework/scala/context/ApplicationContextConversions.scala
+++ b/src/main/scala/org/springframework/scala/context/ApplicationContextConversions.scala
@@ -57,4 +57,8 @@ private[springframework] class DefaultRichApplicationContext(val appContext: App
 	def beansOfType[T](includeNonSingletons: Boolean, allowEagerInit: Boolean)
 	                  (implicit manifest: Manifest[T]) = beanFactory
 			.beansOfType(includeNonSingletons, allowEagerInit)(manifest)
+
+	def beansOfType[T](implicit manifest: Manifest[T]): Map[String, T] =
+		beansOfType[T]()
+
 }

--- a/src/main/scala/org/springframework/scala/context/function/FunctionalConfigApplicationContext.scala
+++ b/src/main/scala/org/springframework/scala/context/function/FunctionalConfigApplicationContext.scala
@@ -21,7 +21,7 @@ import org.springframework.util.CollectionUtils
 import scala.collection.JavaConversions._
 import org.springframework.beans.BeanUtils
 import org.springframework.beans.factory.support.{DefaultBeanNameGenerator, BeanNameGenerator}
-import org.springframework.scala.context.RichApplicationContext
+import org.springframework.scala.context.{DefaultRichApplicationContext, RichApplicationContext}
 import org.springframework.scala.util.ManifestUtils.manifestToClass
 
 /**
@@ -94,6 +94,9 @@ class FunctionalConfigApplicationContext
 	def beansOfType[T](includeNonSingletons: Boolean, allowEagerInit: Boolean)
 	                  (implicit manifest: Manifest[T]) = richApplicationContext
 			.beansOfType(includeNonSingletons, allowEagerInit)(manifest)
+
+	def beansOfType[T](implicit manifest: Manifest[T]): Map[String, T] =
+		beansOfType[T]()
 }
 
 /**

--- a/src/test/scala/org/springframework/scala/context/function/FunctionalConfigApplicationContextTests.scala
+++ b/src/test/scala/org/springframework/scala/context/function/FunctionalConfigApplicationContextTests.scala
@@ -59,6 +59,10 @@ class FunctionalConfigApplicationContextTests extends FunSuite {
 		assert("Foo" == foo)
 	}
 
-
+	test("context.beansOfType[String] call without empty parameter list") {
+		val appContext = FunctionalConfigApplicationContext(classOf[MyFunctionalConfiguration])
+		val foos : Map[String,String] = appContext.beansOfType[String]
+		assert(1 === foos.size)
+	}
 
 }


### PR DESCRIPTION
Hi,

If you try to execute `FunctionalConfigApplicationContext.beansOfType` method without empty pair of parentheses, you will get partially applied function instead of map of beans.

```
val strings = ctx.beansOfType[String]
// Compilation error below! 
// Partially applied function returned instead of Map[String,String].
strings.size
```

I think that end-users will execute `ctx.beansOfType[String]` while intending to call `ctx.beansOfType[String]()`. In order to avoid user confusion and provide syntactic sugar, I propose to add overloaded version of the `FunctionalConfigApplicationContext.beansOfType` without a list of parameters.  

```
val strings = ctx.beansOfType[String]
// Compiles, Map[String,String] retrieved.
strings.size
```

Cheers.

PS Scaladoc on demand.
