### PR TITLE
Added Cobertura task to Gradle.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,6 +8,8 @@ apply plugin: 'propdeps-maven'
 apply plugin: 'propdeps-idea'
 apply plugin: 'propdeps-eclipse'
 
+apply from: 'cobertura.gradle'
+
 group 'org.springframework.scala'
 
 ext {
@@ -17,6 +19,7 @@ ext {
 
 repositories {
   maven { url "http://repo.springsource.org/libs-snapshot" }
+  mavenCentral()
 }
 
 dependencies {

--- a/cobertura.gradle
+++ b/cobertura.gradle
@@ -1,0 +1,55 @@
+def coberturaDependency = 'net.sourceforge.cobertura:cobertura:1.9.4.1'
+
+logger.info 'Configuring Cobertura Plugin'
+
+configurations {
+    coberturaRuntime { extendsFrom testRuntime }
+}
+
+dependencies {
+    coberturaRuntime coberturaDependency
+}
+
+def serFile = "${project.buildDir}/cobertura.ser"
+def classes = "${sourceSets.main.output.classesDir}"
+def coberturaClasses = "${classes}-cobertura"
+
+
+task cobertura(type: Test) {
+    dependencies {
+        testRuntime coberturaDependency
+    }
+
+    systemProperties['net.sourceforge.cobertura.datafile'] = serFile
+}
+
+cobertura.doFirst {
+    if (System.getProperty('java.version').startsWith('1.7')) {
+        logger.warn 'Cobertura requires Java version <= 1.6 to work correctly. Skipping Cobertura instrumentation.'
+    } else {
+        logger.quiet 'Instrumenting classes for Cobertura'
+        ant {
+            delete(file: serFile, failonerror: false)
+            delete(dir: coberturaClasses, failonerror: false)
+            copy(todir: coberturaClasses) { fileset(dir: classes) }
+
+            taskdef(resource: 'tasks.properties', classpath: configurations.coberturaRuntime.asPath)
+            'cobertura-instrument'(datafile: serFile) {
+                fileset(dir: classes,
+                        includes: '**/*.class',
+                        excludes: '**/*Test.class')
+            }
+        }
+    }
+}
+
+cobertura.doLast {
+    if (new File(coberturaClasses).exists()) {
+        ant.'cobertura-report'(destdir: "${reporting.baseDir}/cobertura",
+                format: 'html', srcdir: 'src/main/scala', datafile: serFile)
+
+        ant.delete(file: classes)
+        ant.move(file: coberturaClasses, tofile: classes)
+    }
+
+}


### PR DESCRIPTION
Hi,

I was thinking about two stack overflow bugs I've fixed lately. And I came to conclusion that we could had easily spotted them earlier with test coverage checks. From my experience Cobertura works pretty good as Scala test coverage tool.

Unfortunately in Gradle you cannot use Cobertura out of the box (as in Maven), so I created a dedicated Gradle task to generate Cubertura report.

Now, if you want to generate test coverage report, you just execute `gradle cobertura`. After the execution of the latter command, you will see brand new coverage report in HTML format located under `spring-scala/build/reports/cobertura/index.html`.

Keep in mind that I added Maven Central repository to the `build.gradle` because the Cobertura task needs to resolve `net.sourceforge.cobertura:cobertura:1.9.4.1` dependency. If you add mentioned dependency to the Spring Source repository, you can safely remove Maven Central from `build.gradle`.

Armed with Cobertura I could improve our test coverage with some further contributions.

Best regards.
