### PR TITLE
Added basic support for Spring Test.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ dependencies {
   optional("org.springframework:spring-jdbc:$springVersion")
   optional("org.springframework:spring-jms:$springVersion")
   optional("org.springframework:spring-web:$springVersion")
+  optional("org.springframework:spring-test:$springVersion")
 
   // Scala
 //  scalaTools("org.scala-lang:scala-compiler:$scalaVersion")

--- a/src/main/scala/org/springframework/scala/test/context/FunctionalConfigContextLoader.scala
+++ b/src/main/scala/org/springframework/scala/test/context/FunctionalConfigContextLoader.scala
@@ -1,0 +1,46 @@
+package org.springframework.scala.test.context
+
+import org.springframework.context.ApplicationContext
+import org.springframework.context.annotation.AnnotationConfigUtils.registerAnnotationConfigProcessors
+import org.springframework.scala.context.function.{FunctionalConfiguration, FunctionalConfigApplicationContext}
+import org.springframework.test.context.{SmartContextLoader, ContextConfigurationAttributes, MergedContextConfiguration}
+
+import scala.UnsupportedOperationException
+
+/**
+ * Implementation of [[org.springframework.test.context.SmartContextLoader]] supporting
+ * [[org.springframework.scala.context.function.FunctionalConfiguration]].
+ * [[org.springframework.scala.context.function.FunctionalConfigApplicationContext]] started by this loader has
+ * annotation config support enabled out of the box.
+ *
+ * @author Henryk Konsek
+ */
+class FunctionalConfigContextLoader extends SmartContextLoader {
+
+  /**
+   * Sequence of [[org.springframework.scala.context.function.FunctionalConfiguration]] to be used by the Spring
+   * to build the test [[org.springframework.context.ApplicationContext]].
+   */
+  private var configClasses: Seq[Class[_ <: FunctionalConfiguration]] = _
+
+  override def processContextConfiguration(configAttributes: ContextConfigurationAttributes) {
+    configClasses = FunctionalConfigurations.resolveConfigurationsFromTestClass(configAttributes.getDeclaringClass)
+  }
+
+  override def loadContext(mergedConfig: MergedContextConfiguration): ApplicationContext = {
+    val context = new FunctionalConfigApplicationContext()
+    context.registerClasses(configClasses: _*)
+    registerAnnotationConfigProcessors(context)
+    context.refresh()
+    context
+  }
+
+  override def processLocations(clazz: Class[_], locations: String*): Array[String] = {
+    throw new UnsupportedOperationException("FunctionalConfigContextLoader supports only SmartContextLoader API.")
+  }
+
+  override def loadContext(locations: String*): ApplicationContext = {
+    throw new UnsupportedOperationException("FunctionalConfigContextLoader supports only SmartContextLoader API.")
+  }
+
+}

--- a/src/main/scala/org/springframework/scala/test/context/FunctionalConfigurations.scala
+++ b/src/main/scala/org/springframework/scala/test/context/FunctionalConfigurations.scala
@@ -1,0 +1,62 @@
+package org.springframework.scala.test.context
+
+import org.springframework.scala.context.function.FunctionalConfiguration
+import org.springframework.util.ClassUtils.{getDefaultClassLoader => defaultClassLoader}
+import scala.annotation.StaticAnnotation
+import scala.reflect.runtime.universe.typeOf
+import scala.reflect.runtime.universe.Constant
+import scala.reflect.runtime.universe.nme
+import scala.reflect.runtime.universe.runtimeMirror
+import scala.reflect.runtime.universe.TypeRef
+
+/**
+ * Annotation specifying the [[org.springframework.scala.context.function.FunctionalConfiguration]] classes that
+ * should be loaded by the Spring Test's [[org.springframework.context.ApplicationContext]]. Used in conjunction with
+ * [[org.springframework.scala.test.context.FunctionalConfigContextLoader]].
+ *
+ * @param classes [[org.springframework.scala.context.function.FunctionalConfiguration]] definitions that should be
+ *                loaded by the Spring Test [[org.springframework.context.ApplicationContext]].
+ *
+ * @author Henryk Konsek
+ */
+case class FunctionalConfigurations(classes: Class[_ <: FunctionalConfiguration]*) extends StaticAnnotation
+
+/**
+ * Companion object for [[org.springframework.scala.test.context.FunctionalConfigurations]] annotation. Contains
+ * mainly miscellaneous helper methods.
+ *
+ * @author Henryk Konsek
+ */
+object FunctionalConfigurations {
+
+  /**
+   * Retrieves the [[org.springframework.scala.context.function.FunctionalConfiguration]] classes definitions from the
+   * test class annotated with the [[org.springframework.scala.test.context.FunctionalConfigurations]].
+   *
+   * @param testClass test class to be examined (annotated with the
+   *                  [[org.springframework.scala.test.context.FunctionalConfigurations]]).
+   * @return Sequence of [[org.springframework.scala.context.function.FunctionalConfiguration]]s extracted from the
+   *         [[org.springframework.scala.test.context.FunctionalConfigurations]] annotation. Empty sequence if no
+   *         functional configuration class has been provided or
+   *         [[org.springframework.scala.test.context.FunctionalConfigurations]] annotation is missing.
+   */
+  def resolveConfigurationsFromTestClass(testClass: Class[_]): Seq[Class[_ <: FunctionalConfiguration]] = {
+    val mirror = runtimeMirror(defaultClassLoader)
+    val configurationsAnnotationType = typeOf[FunctionalConfigurations]
+    val testClassSymbol = mirror.classSymbol(testClass)
+
+    testClassSymbol.annotations.find(_.tpe == configurationsAnnotationType) match {
+      case Some(annotation) => {
+        val configurationsAnnotationArgs = annotation.scalaArgs.map {
+          arg => mirror.runtimeClass(arg.productElement(0).asInstanceOf[Constant].value.asInstanceOf[TypeRef])
+        }
+        val annotationMirror = mirror.reflectClass(configurationsAnnotationType.typeSymbol.asClass)
+        val constructorSymbol = configurationsAnnotationType.declaration(nme.CONSTRUCTOR).asMethod
+        val constructorMirror = annotationMirror.reflectConstructor(constructorSymbol)
+        constructorMirror(configurationsAnnotationArgs.seq).asInstanceOf[FunctionalConfigurations].classes
+      }
+      case None => Seq()
+    }
+  }
+
+}

--- a/src/test/scala/org/springframework/scala/test/context/ScalaJUnitTests.scala
+++ b/src/test/scala/org/springframework/scala/test/context/ScalaJUnitTests.scala
@@ -1,0 +1,44 @@
+package org.springframework.scala.test.context
+
+import org.springframework.test.context.ContextConfiguration
+import org.junit.Test
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner
+import org.junit.runner.RunWith
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.scala.context.function.FunctionalConfiguration
+import java.util.Date
+
+@RunWith(classOf[SpringJUnit4ClassRunner])
+@ContextConfiguration(loader = classOf[FunctionalConfigContextLoader])
+@FunctionalConfigurations(classOf[TestConfig], classOf[AnotherTestConfig])
+class ScalaJUnitTests {
+
+  @Autowired
+  var stringBean : String = _
+
+  @Autowired
+  var dateBean : Date = _
+
+  @Test
+  def shouldInjectStringBean() {
+    assert(stringBean == "stringBean")
+  }
+
+  @Test
+  def shouldInjectDateBean() {
+    assert(dateBean != null)
+  }
+
+}
+
+class TestConfig extends FunctionalConfiguration {
+
+  bean("stringBean")("stringBean")
+
+}
+
+class AnotherTestConfig extends FunctionalConfiguration {
+
+  bean("dateBean")(new Date)
+
+}


### PR DESCRIPTION
Hi,

Current version of Spring Scala doesn't play well with the existing Spring Test infrastructure. There is much to be done in this area, but the fundamental issue is probably the lack of `ContextLoader` dedicated for the `FunctionalConfiguration` classes (as reported by @nfrankel).

I created `FunctionalConfigContextLoader` class and `FunctionalConfigurations` annotation to make it possible to wire functional configurations into the Spring Test JUnit runner.

```
@RunWith(classOf[SpringJUnit4ClassRunner])
@ContextConfiguration(loader = classOf[FunctionalConfigContextLoader])
@FunctionalConfigurations(classOf[TestConfig], classOf[AnotherTestConfig])
class ScalaJUnitTests {

  @Autowired
  var stringBean : String = _

  @Test
  def someTest() {}

}
```

I deliberately do not use `@ContextConfiguration.classes` property to provide the list of `FunctionalConfiguration` classes, as the contract of this property clearly states that it should be used only to specify `@Configuration` classes.

There is much more that could be done to improve the experience of Spring Scala users with Spring Test. This contribution would be the very first move toward this effort.

Cheers.
