### PR TITLE
Added support for profiles to FunctionalConfigContextLoader.

### DIFF
--- a/src/main/scala/org/springframework/scala/test/context/FunctionalConfigContextLoader.scala
+++ b/src/main/scala/org/springframework/scala/test/context/FunctionalConfigContextLoader.scala
@@ -19,7 +19,8 @@ package org.springframework.scala.test.context
 import org.springframework.context.ApplicationContext
 import org.springframework.context.annotation.AnnotationConfigUtils.registerAnnotationConfigProcessors
 import org.springframework.scala.context.function.{FunctionalConfiguration, FunctionalConfigApplicationContext}
-import org.springframework.test.context.{SmartContextLoader, ContextConfigurationAttributes, MergedContextConfiguration}
+import org.springframework.test.context.{ContextConfigurationAttributes, MergedContextConfiguration}
+import org.springframework.test.context.support.AbstractContextLoader
 
 import scala.UnsupportedOperationException
 
@@ -32,7 +33,7 @@ import scala.UnsupportedOperationException
  *
  * @author Henryk Konsek
  */
-class FunctionalConfigContextLoader extends SmartContextLoader {
+class FunctionalConfigContextLoader extends AbstractContextLoader {
 
   private var configClasses: Seq[Class[_ <: FunctionalConfiguration]] = _
 
@@ -42,18 +43,19 @@ class FunctionalConfigContextLoader extends SmartContextLoader {
 
   override def loadContext(mergedConfig: MergedContextConfiguration): ApplicationContext = {
     val context = new FunctionalConfigApplicationContext()
+    prepareContext(context, mergedConfig)
     context.registerClasses(configClasses: _*)
     registerAnnotationConfigProcessors(context)
     context.refresh()
     context
   }
 
-  override def processLocations(clazz: Class[_], locations: String*): Array[String] = {
+  override def loadContext(locations: String*): ApplicationContext = {
     throw new UnsupportedOperationException("FunctionalConfigContextLoader supports only SmartContextLoader API.")
   }
 
-  override def loadContext(locations: String*): ApplicationContext = {
-    throw new UnsupportedOperationException("FunctionalConfigContextLoader supports only SmartContextLoader API.")
+  override def getResourceSuffix: String = {
+    throw new UnsupportedOperationException("FunctionalConfigContextLoader does not support the getResourceSuffix() method")
   }
 
 }

--- a/src/test/scala/org/springframework/scala/test/context/ProfiledFunctionalConfigurationsTests.scala
+++ b/src/test/scala/org/springframework/scala/test/context/ProfiledFunctionalConfigurationsTests.scala
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2011-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.scala.test.context
+
+import org.springframework.test.context.{ActiveProfiles, ContextConfiguration}
+import org.junit.Test
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner
+import org.junit.runner.RunWith
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.scala.context.function.FunctionalConfiguration
+import java.util.Date
+
+@RunWith(classOf[SpringJUnit4ClassRunner])
+@ContextConfiguration(loader = classOf[FunctionalConfigContextLoader])
+@FunctionalConfigurations(classOf[ProfiledTestConfig])
+@ActiveProfiles(Array("activeProfile"))
+class ProfiledFunctionalConfigurationsTests {
+
+  @Autowired
+  var stringBean: String = _
+
+  @Autowired(required = false)
+  var dateBean: Date = _
+
+  @Test
+  def shouldInjectBeanFromActiveProfile() {
+    assert("stringBean" == stringBean)
+  }
+
+  @Test
+  def shouldNotInjectBeanFromInactiveProfile() {
+    assert(null == dateBean)
+  }
+
+}
+
+class ProfiledTestConfig extends FunctionalConfiguration {
+
+  profile("activeProfile") {
+    bean("stringBean")("stringBean")
+  }
+
+  profile("inactiveProfile") {
+    bean("dateBean")(new Date)
+  }
+
+}


### PR DESCRIPTION
Hi,

As @alexbool noticed, current implementation of `FunctionalConfigContextLoader` doesn't support profiles. I changed the superclass of the `FunctionalConfigContextLoader` to make call to existing logic responsible for parsing `@ActiveProfiles` annotation.

Thanks @alexbool!

Cheers.
