### PR TITLE
Changed "last Manifest standing" to the ClassTag.

### DIFF
--- a/src/main/scala/org/springframework/scala/beans/factory/RichListableBeanFactory.scala
+++ b/src/main/scala/org/springframework/scala/beans/factory/RichListableBeanFactory.scala
@@ -86,7 +86,7 @@ trait RichListableBeanFactory extends RichBeanFactory {
 	 * @see FactoryBean#getObjectType
 	 * @see BeanFactoryUtils#beansOfTypeIncludingAncestors(ListableBeanFactory, Class, boolean, boolean)
 	 */
-	def beansOfType[T](implicit manifest: Manifest[T]): Map[String, T] =
+	def beansOfType[T : ClassTag]: Map[String, T] =
 		beansOfType[T]()
 
 	/**


### PR DESCRIPTION
Hi,

This is a low hanging fruit - last Manifest API used in Spring Scala codebase to be converted into `ClassTag`.

Cheers.
