### PR TITLE
Upgraded Scala version. Fixed JMS compilation errors.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ group 'org.springframework.scala'
 
 ext {
   springVersion = '3.2.2.RELEASE'
-  scalaVersion = '2.10.1'
+  scalaVersion = '2.10.2'
 }
 
 repositories {

--- a/src/main/scala/org/springframework/scala/jms/core/JmsTemplate.scala
+++ b/src/main/scala/org/springframework/scala/jms/core/JmsTemplate.scala
@@ -17,6 +17,7 @@
 package org.springframework.scala.jms.core
 
 import javax.jms.{Queue, QueueBrowser, Destination, Message, Session, ConnectionFactory}
+import org.springframework.jms.core.{BrowserCallback, MessagePostProcessor, MessageCreator, JmsOperations}
 
 /**
  * Scala-based convenience wrapper for the Spring [[org.springframework.jms.core.JmsTemplate]], taking


### PR DESCRIPTION
Hi Arjen,

I upgraded the version of the Scala to 2.10.2 .

In order to build the project I also needed to fix `JmsTemplate` imports, as you apparently removed some of them by mistake in commit 74b107a (Copyright notice).

Best regards.
