### PR TITLE
Fixed a deprecated warning - changed import from scala.reflect.BeanProperty to scala.beans.BeanProperty

### DIFF
--- a/src/test/scala/org/springframework/scala/beans/ScalaBean.scala
+++ b/src/test/scala/org/springframework/scala/beans/ScalaBean.scala
@@ -16,7 +16,7 @@
 
 package org.springframework.scala.beans
 
-import scala.reflect.BeanProperty
+import scala.beans.BeanProperty
 
 class ScalaBean {
 


### PR DESCRIPTION
Minor change to fix a deprecation warning - from scala.reflect.BeanProperty to scala.beans.BeanProperty
