### PR TITLE
Make RestTemplate work with Scala case classes, collections etc.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ build
 *.iws
 .idea
 out
+/bin

--- a/build.gradle
+++ b/build.gradle
@@ -14,9 +14,11 @@ archivesBaseName = "spring-scala_2.10"
 ext {
   springVersion = '3.2.4.RELEASE'
   scalaVersion = '2.10.2'
+  jacksonModuleScalaVersion = '2.1.2'
 }
 
 repositories {
+  mavenCentral()
   maven { url "http://repo.springsource.org/libs-snapshot" }
 }
 
@@ -34,6 +36,9 @@ dependencies {
   // Scala
   compile("org.scala-lang:scala-library:$scalaVersion")
   compile("org.scala-lang:scala-reflect:$scalaVersion")
+
+  // Jackson
+  optional("com.fasterxml.jackson.module:jackson-module-scala:$jacksonModuleScalaVersion")
 
   // Java EE
   provided("org.apache.geronimo.specs:geronimo-jms_1.1_spec:1.1")


### PR DESCRIPTION
Add DefaultScalaModule to the message converter of MappingJackson2HttpMessageConverter
type if both types are present. This allows RestTemplate to work with case classes,
Scala collection etc.
