### PR TITLE
Added constructor support for autowiring in Scala

### DIFF
--- a/src/main/scala/org/springframework/scala/context/annotation/ConstructorAutowiredAnnotationBeanPostProcessor.scala
+++ b/src/main/scala/org/springframework/scala/context/annotation/ConstructorAutowiredAnnotationBeanPostProcessor.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.springframework.scala.beans.factory.annotation
+package org.springframework.scala.context.annotation
 
 import java.lang.reflect.Constructor
 import org.springframework.beans.factory.annotation.{AutowiredAnnotationBeanPostProcessor, Autowired}

--- a/src/test/scala/org/springframework/scala/beans/factory/annotation/ConstructorAutowiredAnnotationBeanPostProcessorTest.scala
+++ b/src/test/scala/org/springframework/scala/beans/factory/annotation/ConstructorAutowiredAnnotationBeanPostProcessorTest.scala
@@ -20,6 +20,7 @@ import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 import org.scalatest.FunSuite
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.scala.context.annotation.ConstructorAutowiredAnnotationBeanPostProcessor
 
 /** @author Stephen Samuel */
 @RunWith(classOf[JUnitRunner])


### PR DESCRIPTION
This additions allows us to use a much better form of autowiring, allowing immutable service classes.

Instead of 

``` scala
@Component
class MyService {
  @Autowired var something : SomeDep = _
  .... 
}
```

Which results in "ugly" vars and mutable state, we can now use idiomatic scala and do

``` scala
@Component
@Autowired
class MyService(something : SomeDep) { ... }
```

Which allows proper immutable classes. Feedback appreciated. This is quite a common question on stack overflow.
