### PR TITLE
Implements Ordered so that always runs before ExtendedBeanInfoFactory

### DIFF
--- a/src/main/java/org/springframework/scala/beans/ScalaBeanInfoFactory.java
+++ b/src/main/java/org/springframework/scala/beans/ScalaBeanInfoFactory.java
@@ -16,11 +16,13 @@
 
 package org.springframework.scala.beans;
 
+
 import java.beans.BeanInfo;
 import java.beans.IntrospectionException;
 import java.lang.reflect.Method;
 
 import org.springframework.beans.BeanInfoFactory;
+import org.springframework.core.Ordered;
 
 /**
  * Implementation of the {@code BeanInfoFactory} interface for Scala beans.
@@ -32,7 +34,7 @@ import org.springframework.beans.BeanInfoFactory;
  *
  * @author Arjen Poutsma
  */
-public class ScalaBeanInfoFactory implements BeanInfoFactory {
+public class ScalaBeanInfoFactory implements Ordered, BeanInfoFactory {
 
 	@Override
 	public BeanInfo getBeanInfo(Class<?> beanClass) throws IntrospectionException {
@@ -49,4 +51,8 @@ public class ScalaBeanInfoFactory implements BeanInfoFactory {
 		return false;
 	}
 
+	@Override
+	public int getOrder() {
+		return Ordered.LOWEST_PRECEDENCE - 1000;
+	}
 }


### PR DESCRIPTION
`ScalaBeanInfoFactory` does not implement `Ordered` interface. Thus when `SpringFactoriesLoader.loadFactories()` locates all available factories, the order between `BeanInfoFactory` and `ExtendedBeanInfoFactory` is unspecified.

This may become a problem if both factories accept given bean (when Scala class has Java setter by coincidence) - `ExtendedBeanInfoFactory` fails to recognize Scala setters later on. To make matters worse the order of these two classes is unspecified - it is related to the order of Spring JARs on the CLASSPATH. This means that for example injection works in IDE but fails in maven...

This PR makes it explicit which factory is picked up first.
