### PR TITLE
Added classTagged version of FunctionalConfiguration#importClass method

### DIFF
--- a/src/main/scala/org/springframework/scala/context/function/FunctionalConfiguration.scala
+++ b/src/main/scala/org/springframework/scala/context/function/FunctionalConfiguration.scala
@@ -281,6 +281,16 @@ trait FunctionalConfiguration extends DelayedInit {
 	}
 
 	/**
+	* Convenience version of the ``importClass(annotatedClasses: Class[_]*)`` method using class tag instead of class
+	* literal.
+	*
+	* @tparam T configuration class to import
+ 	*/
+	protected def importClass[T : ClassTag]() {
+		importClass(typeToClass[T])
+	}
+
+	/**
 	 * Registers this functional configuration class with the given application context.
 	 *
 	 * @param applicationContext the application context

--- a/src/test/scala/org/springframework/scala/context/function/FunctionalConfigurationTests.scala
+++ b/src/test/scala/org/springframework/scala/context/function/FunctionalConfigurationTests.scala
@@ -301,6 +301,22 @@ class FunctionalConfigurationTests extends FunSuite with BeforeAndAfterEach {
 		assert("Doe" == config.john().lastName)
  	}
 
+  test("importClass via tag") {
+    val config = new FunctionalConfiguration() {
+
+      importClass[MyAnnotatedConfiguration]()
+
+      val john = bean() {
+        new Person(getBean[String]("firstName"), getBean[String]("lastName"))
+      }
+    }
+    config.register(applicationContext, beanNameGenerator)
+    applicationContext.refresh()
+
+    assert("John" == config.john().firstName)
+    assert("Doe" == config.john().lastName)
+  }
+
 	test("beanPostProcessor") {
 		val config = new FunctionalConfiguration {
 


### PR DESCRIPTION
Hi Arjen,

This is yet another quickie :) .

I've added classTagged version of `FunctionalConfiguration#importClass` method. This is syntactic sugar allowing you to import JavaConfig class via `importClass[MyAnnotatedConfiguration]()` instead of `importClass(classOf[MyAnnotatedConfiguration])`.

Cheers.
