### PR TITLE
Exposed the javaTemplate.execute methods on the JmsTemplate 

### DIFF
--- a/src/main/scala/org/springframework/scala/jms/core/JmsTemplate.scala
+++ b/src/main/scala/org/springframework/scala/jms/core/JmsTemplate.scala
@@ -16,9 +16,8 @@
 
 package org.springframework.scala.jms.core
 
-import org.springframework.jms.core.{BrowserCallback, MessagePostProcessor, MessageCreator, JmsOperations}
-import javax.jms.{Queue, QueueBrowser, Destination, Message, Session, ConnectionFactory}
-import org.springframework.jms.core.{BrowserCallback, MessagePostProcessor, MessageCreator, JmsOperations}
+import org.springframework.jms.core._
+import javax.jms._
 
 /**
  * Scala-based convenience wrapper for the Spring [[org.springframework.jms.core.JmsTemplate]], taking
@@ -405,7 +404,32 @@ class JmsTemplate(val javaTemplate: JmsOperations) {
 		javaTemplate.browse(queueName, functionToBrowserCallback(function))
 	}
 
-	private def functionToBrowserCallback[T](function: (Session, QueueBrowser) => T): BrowserCallback[T] =
+  /**
+   * Execute the action specified by the given action object within a JMS Session.
+   * <p>When used with a 1.0.2 provider, you may need to downcast
+   * to the appropriate domain implementation, either QueueSession or
+   * TopicSession in the action objects doInJms callback method.
+   * @param function Function object that exposes the session
+   * @return the result object from working with the session
+   * @throws JmsException if there is any problem
+   */
+  def execute[T](function : Session => T) = javaTemplate.execute(new SessionCallback[T] {
+    override def doInJms(session: Session): T = function(session)
+  })
+
+  /**
+   * Send messages to the default JMS destination (or one specified
+   * for each send operation). The callback gives access to the JMS Session
+   * and MessageProducer in order to perform complex send operations.
+   * @param function Function object that exposes the session/producer pair
+   * @return the result object from working with the session
+   * @throws JmsException checked JMSException converted to unchecked
+   */
+  def execute[T](function : (Session, MessageProducer) => T) = javaTemplate.execute(new ProducerCallback[T] {
+    override def doInJms(session: Session, producer: MessageProducer): T = function(session,producer)
+  })
+
+  private def functionToBrowserCallback[T](function: (Session, QueueBrowser) => T): BrowserCallback[T] =
 		new BrowserCallback[T] {
 			def doInJms(session: Session, browser: QueueBrowser) = function(session, browser)
 		}


### PR DESCRIPTION
Makes it easier to use the bare session:

For example 

``` scala
template.execute(session => session.createTemporaryQueue())
```
