### PR TITLE
Concurrent map feature

### DIFF
--- a/src/main/scala/org/springframework/scala/beans/factory/function/InitDestroyFunctionBeanPostProcessor.scala
+++ b/src/main/scala/org/springframework/scala/beans/factory/function/InitDestroyFunctionBeanPostProcessor.scala
@@ -16,6 +16,8 @@
 
 package org.springframework.scala.beans.factory.function
 
+import java.util.{concurrent => juc}
+
 import scala.beans.BeanProperty
 import scala.collection.mutable
 import scala.collection.mutable.ListBuffer
@@ -41,9 +43,11 @@ import org.springframework.util.{Assert, StringUtils}
 class InitDestroyFunctionBeanPostProcessor
 		extends DestructionAwareBeanPostProcessor with PriorityOrdered {
 
-	val initFunctions = new mutable.HashMap[String, ListBuffer[Function1[Any, Unit]]]
+  import scala.collection.JavaConversions._
 
-	val destroyFunctions = new mutable.HashMap[String, ListBuffer[Function1[Any, Unit]]]
+	val initFunctions: mutable.Map[String,ListBuffer[Function1[Any, Unit]]] = new juc.ConcurrentHashMap[String, ListBuffer[Function1[Any, Unit]]]
+
+	val destroyFunctions: mutable.Map[String,ListBuffer[Function1[Any, Unit]]] = new juc.ConcurrentHashMap[String, ListBuffer[Function1[Any, Unit]]]
 
 	@BeanProperty
 	var order: Int = org.springframework.core.Ordered.LOWEST_PRECEDENCE
@@ -82,7 +86,7 @@ class InitDestroyFunctionBeanPostProcessor
 		addFunction(destroyFunctions, beanName, destroyFunction.asInstanceOf[Function1[Any, Unit]])
 	}
 
-	private def addFunction(functionsMap: mutable.HashMap[String, ListBuffer[Function1[Any, Unit]]],
+	private def addFunction(functionsMap: mutable.Map[String, ListBuffer[Function1[Any, Unit]]],
 	                        beanName: String,
 	                        function: (Any) => Unit) {
 


### PR DESCRIPTION
Untill last commit there were maps with concurrency capability via [cake](https://github.com/spring-projects/spring-scala/blob/3b6ab283cd58a68ab185dc6f6280d65e30aa0bda/src/main/scala/org/springframework/scala/beans/factory/function/InitDestroyFunctionBeanPostProcessor.scala#L46-L50) pattern.

But such trait was deprecated since `2.11`. Thus it's usage is not recommended anymore.

I'm not sure, why it was necessary to have those value synchronized in the first place (perhaps, because values are public) , but I'd suggest to use instances of `java.util.concurrent.ConcurrentHashMap`, which are naturally converted with [Scala Collection Conversions](http://www.scala-lang.org/api/current/index.html#scala.collection.JavaConversions$).
