### PR TITLE
Add Travis CI support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: java
+jdk:
+- openjdk7
+- oraclejdk7
+- oraclejdk8


### PR DESCRIPTION
Majority of open-source projects uses [Travis CI](http://travis-ci.org/) as continuous integration server for all builds and PRs. This might be helpful, as you can see that the project is working fine on all environment, specified in README.

Particularly, my first travis push indicated, that this project doesn't work for Oracle JDK 1.8. I might fix it in the next PR, but this one is for your consideration.

Cheers, Nick.
