### PR TITLE
URL Cleanup

### DIFF
--- a/src/test/resources/org/springframework/scala/beans/factory/xml/utilNamespaceHandlerTest.xml
+++ b/src/test/resources/org/springframework/scala/beans/factory/xml/utilNamespaceHandlerTest.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:scala-util="http://www.springframework.org/schema/scala/util"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/scala/util http://www.springframework.org/schema/scala/util/scala-util.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/scala/util https://www.springframework.org/schema/scala/util/scala-util.xsd">
 
     <bean class="org.springframework.beans.factory.config.CustomEditorConfigurer">
         <property name="propertyEditorRegistrars">

--- a/src/test/resources/org/springframework/scala/beans/propertyeditors/scalaEditorRegistrarTest.xml
+++ b/src/test/resources/org/springframework/scala/beans/propertyeditors/scalaEditorRegistrarTest.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:util="http://www.springframework.org/schema/util"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd">
 
     <bean id="configurer" class="org.springframework.beans.factory.config.CustomEditorConfigurer">
         <property name="propertyEditorRegistrars">

--- a/src/test/resources/org/springframework/scala/beans/scalaBeanInfoFactoryIntegrationTest.xml
+++ b/src/test/resources/org/springframework/scala/beans/scalaBeanInfoFactoryIntegrationTest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
     <bean id="scalaBean" class="org.springframework.scala.beans.ScalaBean">
         <property name="readWrite" value="Bar"/>

--- a/src/test/resources/org/springframework/scala/context/function/imported.xml
+++ b/src/test/resources/org/springframework/scala/context/function/imported.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
     <bean id="firstName" class="java.lang.String">
         <constructor-arg value="John"/>


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://www.springframework.org/schema/scala/util/scala-util.xsd (404) with 1 occurrences migrated to:  
  https://www.springframework.org/schema/scala/util/scala-util.xsd ([https](https://www.springframework.org/schema/scala/util/scala-util.xsd) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://www.springframework.org/schema/beans/spring-beans.xsd with 4 occurrences migrated to:  
  https://www.springframework.org/schema/beans/spring-beans.xsd ([https](https://www.springframework.org/schema/beans/spring-beans.xsd) result 200).
* http://www.springframework.org/schema/util/spring-util.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/util/spring-util.xsd ([https](https://www.springframework.org/schema/util/spring-util.xsd) result 200).

# Ignored
These URLs were intentionally ignored.

* http://www.springframework.org/schema/beans with 8 occurrences
* http://www.springframework.org/schema/scala/util with 2 occurrences
* http://www.springframework.org/schema/util with 2 occurrences
* http://www.w3.org/2001/XMLSchema-instance with 4 occurrences