### PR TITLE
URL Cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,5 +5,5 @@ The goal of Spring Scala is to make it easier to use the Spring framework in Sca
 **Spring Scala development within Pivotal has ceased, but fortunately a member
 of the community - Paul Snively - has stepped up and is continuing development
 over at
-[http://hub.darcs.net/psnively/spring-scala](http://hub.darcs.net/psnively/spring-scala).
+[https://hub.darcs.net/psnively/spring-scala](https://hub.darcs.net/psnively/spring-scala).
 Please refer to that repository instead of this one, which might be removed in the future.**

--- a/src/main/resources/org/springframework/scala/beans/factory/xml/scala-util-1.0.xsd
+++ b/src/main/resources/org/springframework/scala/beans/factory/xml/scala-util-1.0.xsd
@@ -7,8 +7,8 @@
             elementFormDefault="qualified"
             attributeFormDefault="unqualified">
 
-	<xsd:import namespace="http://www.springframework.org/schema/beans" schemaLocation="http://www.springframework.org/schema/beans/spring-beans-3.1.xsd"/>
-	<xsd:import namespace="http://www.springframework.org/schema/tool" schemaLocation="http://www.springframework.org/schema/tool/spring-tool-3.0.xsd"/>
+	<xsd:import namespace="http://www.springframework.org/schema/beans" schemaLocation="https://www.springframework.org/schema/beans/spring-beans-3.1.xsd"/>
+	<xsd:import namespace="http://www.springframework.org/schema/tool" schemaLocation="https://www.springframework.org/schema/tool/spring-tool-3.0.xsd"/>
 
     <xsd:element name="seq">
 		<xsd:annotation>


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://hub.darcs.net/psnively/spring-scala with 2 occurrences migrated to:  
  https://hub.darcs.net/psnively/spring-scala ([https](https://hub.darcs.net/psnively/spring-scala) result 200).
* [ ] http://www.springframework.org/schema/beans/spring-beans-3.1.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/beans/spring-beans-3.1.xsd ([https](https://www.springframework.org/schema/beans/spring-beans-3.1.xsd) result 200).
* [ ] http://www.springframework.org/schema/tool/spring-tool-3.0.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/tool/spring-tool-3.0.xsd ([https](https://www.springframework.org/schema/tool/spring-tool-3.0.xsd) result 200).

# Ignored
These URLs were intentionally ignored.

* http://www.springframework.org/schema/beans with 2 occurrences
* http://www.springframework.org/schema/scala/util with 1 occurrences
* http://www.springframework.org/schema/tool with 2 occurrences
* http://www.springframework.org/schema/util with 1 occurrences
* http://www.w3.org/2001/XMLSchema with 1 occurrences