### PR TITLE
URL Cleanup

### DIFF
--- a/src/main/java/org/springframework/scala/beans/ScalaBeanInfo.java
+++ b/src/main/java/org/springframework/scala/beans/ScalaBeanInfo.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/org/springframework/scala/beans/ScalaBeanInfoFactory.java
+++ b/src/main/java/org/springframework/scala/beans/ScalaBeanInfoFactory.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/org/springframework/scala/beans/factory/function/Function0Wrapper.java
+++ b/src/main/java/org/springframework/scala/beans/factory/function/Function0Wrapper.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/scala/org/springframework/scala/aop/AdviceConversions.scala
+++ b/src/main/scala/org/springframework/scala/aop/AdviceConversions.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/scala/org/springframework/scala/beans/factory/BeanFactoryConversions.scala
+++ b/src/main/scala/org/springframework/scala/beans/factory/BeanFactoryConversions.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/scala/org/springframework/scala/beans/factory/RichBeanFactory.scala
+++ b/src/main/scala/org/springframework/scala/beans/factory/RichBeanFactory.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/scala/org/springframework/scala/beans/factory/RichListableBeanFactory.scala
+++ b/src/main/scala/org/springframework/scala/beans/factory/RichListableBeanFactory.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/scala/org/springframework/scala/beans/factory/annotation/ConstructorAutowiredAnnotationBeanPostProcessor.scala
+++ b/src/main/scala/org/springframework/scala/beans/factory/annotation/ConstructorAutowiredAnnotationBeanPostProcessor.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/scala/org/springframework/scala/beans/factory/config/Function0FactoryBean.scala
+++ b/src/main/scala/org/springframework/scala/beans/factory/config/Function0FactoryBean.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/scala/org/springframework/scala/beans/factory/config/MapFactoryBean.scala
+++ b/src/main/scala/org/springframework/scala/beans/factory/config/MapFactoryBean.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/scala/org/springframework/scala/beans/factory/config/SeqFactoryBean.scala
+++ b/src/main/scala/org/springframework/scala/beans/factory/config/SeqFactoryBean.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/scala/org/springframework/scala/beans/factory/config/SetFactoryBean.scala
+++ b/src/main/scala/org/springframework/scala/beans/factory/config/SetFactoryBean.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/scala/org/springframework/scala/beans/factory/function/FunctionalBeanDefinition.scala
+++ b/src/main/scala/org/springframework/scala/beans/factory/function/FunctionalBeanDefinition.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/scala/org/springframework/scala/beans/factory/function/FunctionalRootBeanDefinition.scala
+++ b/src/main/scala/org/springframework/scala/beans/factory/function/FunctionalRootBeanDefinition.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/scala/org/springframework/scala/beans/factory/function/InitDestroyFunctionBeanPostProcessor.scala
+++ b/src/main/scala/org/springframework/scala/beans/factory/function/InitDestroyFunctionBeanPostProcessor.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/scala/org/springframework/scala/beans/factory/xml/UtilNamespaceHandler.scala
+++ b/src/main/scala/org/springframework/scala/beans/factory/xml/UtilNamespaceHandler.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/scala/org/springframework/scala/beans/propertyeditors/RegexEditor.scala
+++ b/src/main/scala/org/springframework/scala/beans/propertyeditors/RegexEditor.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/scala/org/springframework/scala/beans/propertyeditors/ScalaCollectionEditor.scala
+++ b/src/main/scala/org/springframework/scala/beans/propertyeditors/ScalaCollectionEditor.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/scala/org/springframework/scala/beans/propertyeditors/ScalaEditorRegistrar.scala
+++ b/src/main/scala/org/springframework/scala/beans/propertyeditors/ScalaEditorRegistrar.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/scala/org/springframework/scala/context/ApplicationContextConversions.scala
+++ b/src/main/scala/org/springframework/scala/context/ApplicationContextConversions.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/scala/org/springframework/scala/context/ApplicationListenerAdapter.scala
+++ b/src/main/scala/org/springframework/scala/context/ApplicationListenerAdapter.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/scala/org/springframework/scala/context/RichApplicationContext.scala
+++ b/src/main/scala/org/springframework/scala/context/RichApplicationContext.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/scala/org/springframework/scala/context/function/BeanLookupFunction.scala
+++ b/src/main/scala/org/springframework/scala/context/function/BeanLookupFunction.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/scala/org/springframework/scala/context/function/ContextSupport.scala
+++ b/src/main/scala/org/springframework/scala/context/function/ContextSupport.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/scala/org/springframework/scala/context/function/FunctionalConfigApplicationContext.scala
+++ b/src/main/scala/org/springframework/scala/context/function/FunctionalConfigApplicationContext.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/scala/org/springframework/scala/context/function/FunctionalConfiguration.scala
+++ b/src/main/scala/org/springframework/scala/context/function/FunctionalConfiguration.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/scala/org/springframework/scala/http/converter/xml/ElemMessageConverter.scala
+++ b/src/main/scala/org/springframework/scala/http/converter/xml/ElemMessageConverter.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/scala/org/springframework/scala/jdbc/core/JdbcCallbackConversions.scala
+++ b/src/main/scala/org/springframework/scala/jdbc/core/JdbcCallbackConversions.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/scala/org/springframework/scala/jdbc/core/JdbcTemplate.scala
+++ b/src/main/scala/org/springframework/scala/jdbc/core/JdbcTemplate.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/scala/org/springframework/scala/jms/core/JmsTemplate.scala
+++ b/src/main/scala/org/springframework/scala/jms/core/JmsTemplate.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/scala/org/springframework/scala/test/context/FunctionalConfigContextLoader.scala
+++ b/src/main/scala/org/springframework/scala/test/context/FunctionalConfigContextLoader.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/scala/org/springframework/scala/test/context/FunctionalConfigurations.scala
+++ b/src/main/scala/org/springframework/scala/test/context/FunctionalConfigurations.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/scala/org/springframework/scala/transaction/function/TransactionMode.scala
+++ b/src/main/scala/org/springframework/scala/transaction/function/TransactionMode.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/scala/org/springframework/scala/transaction/function/TransactionSupport.scala
+++ b/src/main/scala/org/springframework/scala/transaction/function/TransactionSupport.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/scala/org/springframework/scala/transaction/support/SynchronizationEvent.scala
+++ b/src/main/scala/org/springframework/scala/transaction/support/SynchronizationEvent.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/scala/org/springframework/scala/transaction/support/TransactionManagement.scala
+++ b/src/main/scala/org/springframework/scala/transaction/support/TransactionManagement.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/scala/org/springframework/scala/transaction/support/TransactionSynchronizationManager.scala
+++ b/src/main/scala/org/springframework/scala/transaction/support/TransactionSynchronizationManager.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/scala/org/springframework/scala/transaction/support/TransactionTemplate.scala
+++ b/src/main/scala/org/springframework/scala/transaction/support/TransactionTemplate.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/scala/org/springframework/scala/util/TypeTagUtils.scala
+++ b/src/main/scala/org/springframework/scala/util/TypeTagUtils.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/scala/org/springframework/scala/web/client/RestTemplate.scala
+++ b/src/main/scala/org/springframework/scala/web/client/RestTemplate.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/org/springframework/scala/context/function/MyAnnotatedConfiguration.java
+++ b/src/test/java/org/springframework/scala/context/function/MyAnnotatedConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/scala/org/springframework/scala/aop/AdviceConversionsTests.scala
+++ b/src/test/scala/org/springframework/scala/aop/AdviceConversionsTests.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/scala/org/springframework/scala/beans/ScalaBean.scala
+++ b/src/test/scala/org/springframework/scala/beans/ScalaBean.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/scala/org/springframework/scala/beans/ScalaBeanInfoFactoryTests.scala
+++ b/src/test/scala/org/springframework/scala/beans/ScalaBeanInfoFactoryTests.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/scala/org/springframework/scala/beans/ScalaBeanInfoTests.scala
+++ b/src/test/scala/org/springframework/scala/beans/ScalaBeanInfoTests.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/scala/org/springframework/scala/beans/factory/RichBeanFactoryTests.scala
+++ b/src/test/scala/org/springframework/scala/beans/factory/RichBeanFactoryTests.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/scala/org/springframework/scala/beans/factory/RichListableBeanFactoryTests.scala
+++ b/src/test/scala/org/springframework/scala/beans/factory/RichListableBeanFactoryTests.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/scala/org/springframework/scala/beans/factory/annotation/ConstructorAutowiredAnnotationBeanPostProcessorTests.scala
+++ b/src/test/scala/org/springframework/scala/beans/factory/annotation/ConstructorAutowiredAnnotationBeanPostProcessorTests.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/scala/org/springframework/scala/beans/factory/function/FunctionalRootBeanDefinitionTests.scala
+++ b/src/test/scala/org/springframework/scala/beans/factory/function/FunctionalRootBeanDefinitionTests.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/scala/org/springframework/scala/beans/factory/function/InitDestroyFunctionBeanPostProcessorTests.scala
+++ b/src/test/scala/org/springframework/scala/beans/factory/function/InitDestroyFunctionBeanPostProcessorTests.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/scala/org/springframework/scala/beans/propertyeditors/CollectionsBean.scala
+++ b/src/test/scala/org/springframework/scala/beans/propertyeditors/CollectionsBean.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/scala/org/springframework/scala/beans/propertyeditors/PrimitivesBean.scala
+++ b/src/test/scala/org/springframework/scala/beans/propertyeditors/PrimitivesBean.scala
@@ -7,7 +7,7 @@ package org.springframework.scala.beans.propertyeditors
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/scala/org/springframework/scala/beans/propertyeditors/ScalaCollectionEditorTests.scala
+++ b/src/test/scala/org/springframework/scala/beans/propertyeditors/ScalaCollectionEditorTests.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/scala/org/springframework/scala/beans/propertyeditors/ScalaEditorRegistrarTests.scala
+++ b/src/test/scala/org/springframework/scala/beans/propertyeditors/ScalaEditorRegistrarTests.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/scala/org/springframework/scala/beans/propertyeditors/TypesBean.scala
+++ b/src/test/scala/org/springframework/scala/beans/propertyeditors/TypesBean.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/scala/org/springframework/scala/context/ApplicationListenerAdapterTest.scala
+++ b/src/test/scala/org/springframework/scala/context/ApplicationListenerAdapterTest.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/scala/org/springframework/scala/context/function/ComponentScanTests.scala
+++ b/src/test/scala/org/springframework/scala/context/function/ComponentScanTests.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/scala/org/springframework/scala/context/function/ContextSupportTests.scala
+++ b/src/test/scala/org/springframework/scala/context/function/ContextSupportTests.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/scala/org/springframework/scala/context/function/FunctionalConfigApplicationContextTests.scala
+++ b/src/test/scala/org/springframework/scala/context/function/FunctionalConfigApplicationContextTests.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/scala/org/springframework/scala/context/function/FunctionalConfigurationTests.scala
+++ b/src/test/scala/org/springframework/scala/context/function/FunctionalConfigurationTests.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/scala/org/springframework/scala/context/function/MyFunctionalConfiguration.scala
+++ b/src/test/scala/org/springframework/scala/context/function/MyFunctionalConfiguration.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/scala/org/springframework/scala/context/function/Person.scala
+++ b/src/test/scala/org/springframework/scala/context/function/Person.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/scala/org/springframework/scala/jdbc/core/JdbcTemplateTests.scala
+++ b/src/test/scala/org/springframework/scala/jdbc/core/JdbcTemplateTests.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/scala/org/springframework/scala/test/context/FunctionalConfigurationsTests.scala
+++ b/src/test/scala/org/springframework/scala/test/context/FunctionalConfigurationsTests.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/scala/org/springframework/scala/test/context/ProfiledFunctionalConfigurationsTests.scala
+++ b/src/test/scala/org/springframework/scala/test/context/ProfiledFunctionalConfigurationsTests.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/scala/org/springframework/scala/transaction/function/TransactionSupportTests.scala
+++ b/src/test/scala/org/springframework/scala/transaction/function/TransactionSupportTests.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/scala/org/springframework/scala/transaction/support/TransactionManagementTests.scala
+++ b/src/test/scala/org/springframework/scala/transaction/support/TransactionManagementTests.scala
@@ -7,7 +7,7 @@ package org.springframework.scala.transaction.support
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/scala/org/springframework/scala/transaction/support/TransactionSynchronizationManagerTests.scala
+++ b/src/test/scala/org/springframework/scala/transaction/support/TransactionSynchronizationManagerTests.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://www.apache.org/licenses/LICENSE-2.0 with 68 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).